### PR TITLE
fix 生成controller模板中命名空间错误

### DIFF
--- a/src/Command/stubs/controller.stub
+++ b/src/Command/stubs/controller.stub
@@ -6,7 +6,7 @@ namespace %NAMESPACE%;
 use HPlus\Helper\Controller\AbstractBaseController;
 use HPlus\Route\Annotation\ApiController;
 use Hyperf\Di\Annotation\Inject;
-use HPlus\Swagger\Annotation\GetApi;
+use HPlus\Route\Annotation\GetApi;
 
 /**
  * @ApiController(tag="%TITLE%", description="%DESC%")


### PR DESCRIPTION
use HPlus\Route\Annotation\GetApi;